### PR TITLE
Fix (again) essentials integration

### DIFF
--- a/Plugin/src/main/java/com/willfp/ecoenchants/enchantments/EcoEnchant.java
+++ b/Plugin/src/main/java/com/willfp/ecoenchants/enchantments/EcoEnchant.java
@@ -5,6 +5,7 @@ import com.willfp.ecoenchants.Main;
 import com.willfp.ecoenchants.config.ConfigManager;
 import com.willfp.ecoenchants.config.configs.EnchantmentConfig;
 import com.willfp.ecoenchants.nms.Target;
+import com.willfp.ecoenchants.util.EssentialsUtils;
 import org.apache.commons.lang.WordUtils;
 import org.apache.commons.lang.reflect.FieldUtils;
 import org.bukkit.Material;
@@ -102,7 +103,12 @@ public abstract class EcoEnchant extends Enchantment implements Listener {
             Enchantment.registerEnchantment(this);
 
             if(Main.hasEssentials) {
-                ((Map<String, Enchantment>) FieldUtils.readDeclaredStaticField(Enchantments.class, "ENCHANTMENTS", true)).put(this.getKey().getKey(), this);
+                Map<String, Enchantment> essentialsMap = EssentialsUtils.getEnchantmentsMap();
+                if (essentialsMap != null) {
+                    String key = this.getKey().getKey();
+                    essentialsMap.remove(key);
+                    essentialsMap.put(key, this);
+                }
             }
         } catch (NoSuchFieldException | IllegalAccessException ignored) {}
     }

--- a/Plugin/src/main/java/com/willfp/ecoenchants/util/EssentialsUtils.java
+++ b/Plugin/src/main/java/com/willfp/ecoenchants/util/EssentialsUtils.java
@@ -1,0 +1,37 @@
+package com.willfp.ecoenchants.util;
+
+import com.earth2me.essentials.Enchantments;
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.enchantments.Enchantment;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+public class EssentialsUtils {
+    private static Map<String, Enchantment> essentialsEnchantmentsMap;
+    private static boolean hasCheckedEnchantmentsMap;
+
+    @Nullable
+    public static Map<String, Enchantment> getEnchantmentsMap() {
+        if (hasCheckedEnchantmentsMap) return essentialsEnchantmentsMap;
+
+        if (Bukkit.getPluginManager().isPluginEnabled("Essentials")) {
+            try {
+                Class<?> essEnchantmentsClass = Enchantments.class;
+
+                Object enchantments = FieldUtils.readDeclaredStaticField(essEnchantmentsClass, "ENCHANTMENTS", true);
+                if (enchantments instanceof Map) {
+                    hasCheckedEnchantmentsMap = true;
+                    //noinspection unchecked - we know the type of it
+                    return essentialsEnchantmentsMap = (Map<String, Enchantment>) enchantments;
+                }
+            } catch (IllegalAccessException e) {
+                hasCheckedEnchantmentsMap = true;
+                return null;
+            }
+        }
+        hasCheckedEnchantmentsMap = true;
+        return null;
+    }
+}


### PR DESCRIPTION
While you were merging it, the code somehow was gone. This PR introduces the code back.

- Move to getKey instead of getName
- Create a util class for getting the map