### PR TITLE
Fix villager trades not displaying a lore

### DIFF
--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
In order to fix this issue, I had to do the following:
- Bump ProtocolLib version to 4.6.0 (getting the latest version is enough)
- Intercepted the OPEN_WINDOW_MERCHANT and updated the trades' result to include the enchantments. Do note that the items still will only have a lore at the client-side.