### PR TITLE
GitHub Actions

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,38 @@
+name: Test EcoEnchants
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build Maven project
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    # - name: Build Spigot
+    #   # Takes 3 minutes
+    #   # We only build 1.15 because it is the only Spigot version that is not
+    #   # available on their Maven repo
+    #   run: |
+    #     cd ..
+    #     wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+    #     java -jar BuildTools.jar --rev 1.15
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Build EcoEnchants
+      run: |
+        mvn initialize --batch-mode
+        mvn package install --batch-mode

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.15-R0.1-SNAPSHOT</version>
+            <version>1.15.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/NMS/v1_15_R1/pom.xml
+++ b/NMS/v1_15_R1/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.15-R0.1-SNAPSHOT</version>
+            <version>1.15.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
GitHub actions and updated to 1.15.2 so that we don't have to manually build spigot. GitHub actions will only run if they were configured by someone with write access to the repo, so it will not show up on the public repo.

To see how it works, go to: https://github.com/MidasSword/EcoEnchants/actions
