### PR TITLE
Remove final modifiers from villager trading

### DIFF
--- a/eco-core/core-nms/v1_15_R1/src/main/java/com/willfp/ecoenchants/proxy/v1_15_R1/VillagerTrade.java
+++ b/eco-core/core-nms/v1_15_R1/src/main/java/com/willfp/ecoenchants/proxy/v1_15_R1/VillagerTrade.java
@@ -9,16 +9,11 @@ import org.bukkit.inventory.MerchantRecipe;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 
 public final class VillagerTrade implements VillagerTradeProxy {
     @Override
     public void displayTradeEnchantments(@NotNull final MerchantRecipe merchantRecipe) {
         try {
-            // Enables removing final modifier
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-
             // Bukkit MerchantRecipe result
             Field fResult = MerchantRecipe.class.getDeclaredField("result");
             fResult.setAccessible(true);
@@ -30,11 +25,9 @@ public final class VillagerTrade implements VillagerTradeProxy {
             Field fHandle = CraftMerchantRecipe.class.getDeclaredField("handle");
             fHandle.setAccessible(true);
             net.minecraft.server.v1_15_R1.MerchantRecipe handle = (net.minecraft.server.v1_15_R1.MerchantRecipe) fHandle.get(merchantRecipe); // NMS Recipe
-            modifiersField.setInt(fHandle, fHandle.getModifiers() & ~Modifier.FINAL); // Remove final
 
             Field fSelling = net.minecraft.server.v1_15_R1.MerchantRecipe.class.getDeclaredField("sellingItem");
             fSelling.setAccessible(true);
-            modifiersField.setInt(fSelling, fSelling.getModifiers() & ~Modifier.FINAL);
 
             ItemStack selling = CraftItemStack.asBukkitCopy(handle.sellingItem);
             EnchantDisplay.displayEnchantments(selling);

--- a/eco-core/core-nms/v1_16_R1/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R1/VillagerTrade.java
+++ b/eco-core/core-nms/v1_16_R1/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R1/VillagerTrade.java
@@ -9,16 +9,11 @@ import org.bukkit.inventory.MerchantRecipe;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 
 public final class VillagerTrade implements VillagerTradeProxy {
     @Override
     public void displayTradeEnchantments(@NotNull final MerchantRecipe merchantRecipe) {
         try {
-            // Enables removing final modifier
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-
             // Bukkit MerchantRecipe result
             Field fResult = MerchantRecipe.class.getDeclaredField("result");
             fResult.setAccessible(true);
@@ -30,11 +25,9 @@ public final class VillagerTrade implements VillagerTradeProxy {
             Field fHandle = CraftMerchantRecipe.class.getDeclaredField("handle");
             fHandle.setAccessible(true);
             net.minecraft.server.v1_16_R1.MerchantRecipe handle = (net.minecraft.server.v1_16_R1.MerchantRecipe) fHandle.get(merchantRecipe); // NMS Recipe
-            modifiersField.setInt(fHandle, fHandle.getModifiers() & ~Modifier.FINAL); // Remove final
 
             Field fSelling = net.minecraft.server.v1_16_R1.MerchantRecipe.class.getDeclaredField("sellingItem");
             fSelling.setAccessible(true);
-            modifiersField.setInt(fSelling, fSelling.getModifiers() & ~Modifier.FINAL);
 
             ItemStack selling = CraftItemStack.asBukkitCopy(handle.sellingItem);
             EnchantDisplay.displayEnchantments(selling);

--- a/eco-core/core-nms/v1_16_R2/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R2/VillagerTrade.java
+++ b/eco-core/core-nms/v1_16_R2/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R2/VillagerTrade.java
@@ -9,16 +9,11 @@ import org.bukkit.inventory.MerchantRecipe;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 
 public final class VillagerTrade implements VillagerTradeProxy {
     @Override
     public void displayTradeEnchantments(@NotNull final MerchantRecipe merchantRecipe) {
         try {
-            // Enables removing final modifier
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-
             // Bukkit MerchantRecipe result
             Field fResult = MerchantRecipe.class.getDeclaredField("result");
             fResult.setAccessible(true);
@@ -30,11 +25,9 @@ public final class VillagerTrade implements VillagerTradeProxy {
             Field fHandle = CraftMerchantRecipe.class.getDeclaredField("handle");
             fHandle.setAccessible(true);
             net.minecraft.server.v1_16_R2.MerchantRecipe handle = (net.minecraft.server.v1_16_R2.MerchantRecipe) fHandle.get(merchantRecipe); // NMS Recipe
-            modifiersField.setInt(fHandle, fHandle.getModifiers() & ~Modifier.FINAL); // Remove final
 
             Field fSelling = net.minecraft.server.v1_16_R2.MerchantRecipe.class.getDeclaredField("sellingItem");
             fSelling.setAccessible(true);
-            modifiersField.setInt(fSelling, fSelling.getModifiers() & ~Modifier.FINAL);
 
             ItemStack selling = CraftItemStack.asBukkitCopy(handle.sellingItem);
             EnchantDisplay.displayEnchantments(selling);

--- a/eco-core/core-nms/v1_16_R3/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R3/VillagerTrade.java
+++ b/eco-core/core-nms/v1_16_R3/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R3/VillagerTrade.java
@@ -9,16 +9,11 @@ import org.bukkit.inventory.MerchantRecipe;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 
 public final class VillagerTrade implements VillagerTradeProxy {
     @Override
     public void displayTradeEnchantments(@NotNull final MerchantRecipe merchantRecipe) {
         try {
-            // Enables removing final modifier
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-
             // Bukkit MerchantRecipe result
             Field fResult = MerchantRecipe.class.getDeclaredField("result");
             fResult.setAccessible(true);
@@ -30,11 +25,9 @@ public final class VillagerTrade implements VillagerTradeProxy {
             Field fHandle = CraftMerchantRecipe.class.getDeclaredField("handle");
             fHandle.setAccessible(true);
             net.minecraft.server.v1_16_R3.MerchantRecipe handle = (net.minecraft.server.v1_16_R3.MerchantRecipe) fHandle.get(merchantRecipe); // NMS Recipe
-            modifiersField.setInt(fHandle, fHandle.getModifiers() & ~Modifier.FINAL); // Remove final
 
             Field fSelling = net.minecraft.server.v1_16_R3.MerchantRecipe.class.getDeclaredField("sellingItem");
             fSelling.setAccessible(true);
-            modifiersField.setInt(fSelling, fSelling.getModifiers() & ~Modifier.FINAL);
 
             ItemStack selling = CraftItemStack.asBukkitCopy(handle.sellingItem);
             EnchantDisplay.displayEnchantments(selling);


### PR DESCRIPTION
Java 15 does not support changing java.lang.reflect.Field modifiers, causing exceptions to be spammed to the server console and all villager enchanted books to show as a blank enchanted book. 

Tested changes in Java 8, sellingItem is set to the custom enchantment even without altering the final modifier.

Tested in:
Java 1.8 (Java HotSpot(TM) 64-Bit Server VM 25.201-b09)
Java 15 (Java HotSpot(TM) 64-Bit Server VM 15.0.1+9-18)

Side note: 
Plugins need to support Java 11 at a minimum by the time Minecraft 1.17 releases: https://papermc.io/java11
(Java 11 supports Java 8 byte code, but libraries may be different)