### PR TITLE
Fix FastGetEnchants for Enchanted Book

### DIFF
--- a/eco-core/core-nms/v1_16_R1/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R1/FastGetEnchants.java
+++ b/eco-core/core-nms/v1_16_R1/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R1/FastGetEnchants.java
@@ -1,6 +1,8 @@
 package com.willfp.ecoenchants.proxy.v1_16_R1;
 
 import com.willfp.ecoenchants.proxy.proxies.FastGetEnchantsProxy;
+import net.minecraft.server.v1_16_R1.Items;
+import net.minecraft.server.v1_16_R1.ItemEnchantedBook;
 import net.minecraft.server.v1_16_R1.NBTBase;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;
 import net.minecraft.server.v1_16_R1.NBTTagList;
@@ -15,9 +17,9 @@ import java.util.Map;
 
 public final class FastGetEnchants implements FastGetEnchantsProxy {
     @Override
-    public Map<Enchantment, Integer> getEnchantmentsOnItem(@NotNull final ItemStack itemStack) {
+    public Map<Enchantment, Integer> getEnchantmentsOnItem(@NotNull final ItemStack itemStack, boolean checkStored) {
         net.minecraft.server.v1_16_R1.ItemStack nmsStack = CraftItemStack.asNMSCopy(itemStack);
-        NBTTagList enchantmentNBT = nmsStack.getEnchantments();
+        NBTTagList enchantmentNBT = checkStored && nmsStack.getItem() == Items.ENCHANTED_BOOK ? ItemEnchantedBook.d(nmsStack) : nmsStack.getEnchantments();
         HashMap<Enchantment, Integer> foundEnchantments = new HashMap<>();
 
         for (NBTBase base : enchantmentNBT) {
@@ -35,9 +37,10 @@ public final class FastGetEnchants implements FastGetEnchantsProxy {
 
     @Override
     public int getLevelOnItem(@NotNull final ItemStack itemStack,
-                              @NotNull final Enchantment enchantment) {
+                              @NotNull final Enchantment enchantment,
+                              boolean checkStored) {
         net.minecraft.server.v1_16_R1.ItemStack nmsStack = CraftItemStack.asNMSCopy(itemStack);
-        NBTTagList enchantmentNBT = nmsStack.getEnchantments();
+        NBTTagList enchantmentNBT = checkStored && nmsStack.getItem() == Items.ENCHANTED_BOOK ? ItemEnchantedBook.d(nmsStack) : nmsStack.getEnchantments();
 
         for (NBTBase base : enchantmentNBT) {
             NBTTagCompound compound = (NBTTagCompound) base;

--- a/eco-core/core-nms/v1_16_R2/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R2/FastGetEnchants.java
+++ b/eco-core/core-nms/v1_16_R2/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R2/FastGetEnchants.java
@@ -1,6 +1,8 @@
 package com.willfp.ecoenchants.proxy.v1_16_R2;
 
 import com.willfp.ecoenchants.proxy.proxies.FastGetEnchantsProxy;
+import net.minecraft.server.v1_16_R2.Items;
+import net.minecraft.server.v1_16_R2.ItemEnchantedBook;
 import net.minecraft.server.v1_16_R2.NBTBase;
 import net.minecraft.server.v1_16_R2.NBTTagCompound;
 import net.minecraft.server.v1_16_R2.NBTTagList;
@@ -15,9 +17,9 @@ import java.util.Map;
 
 public final class FastGetEnchants implements FastGetEnchantsProxy {
     @Override
-    public Map<Enchantment, Integer> getEnchantmentsOnItem(@NotNull final ItemStack itemStack) {
+    public Map<Enchantment, Integer> getEnchantmentsOnItem(@NotNull final ItemStack itemStack, boolean checkStored) {
         net.minecraft.server.v1_16_R2.ItemStack nmsStack = CraftItemStack.asNMSCopy(itemStack);
-        NBTTagList enchantmentNBT = nmsStack.getEnchantments();
+        NBTTagList enchantmentNBT = checkStored && nmsStack.getItem() == Items.ENCHANTED_BOOK ? ItemEnchantedBook.d(nmsStack) : nmsStack.getEnchantments();
         HashMap<Enchantment, Integer> foundEnchantments = new HashMap<>();
 
         for (NBTBase base : enchantmentNBT) {
@@ -35,9 +37,10 @@ public final class FastGetEnchants implements FastGetEnchantsProxy {
 
     @Override
     public int getLevelOnItem(@NotNull final ItemStack itemStack,
-                              @NotNull final Enchantment enchantment) {
+                              @NotNull final Enchantment enchantment,
+                              boolean checkStored) {
         net.minecraft.server.v1_16_R2.ItemStack nmsStack = CraftItemStack.asNMSCopy(itemStack);
-        NBTTagList enchantmentNBT = nmsStack.getEnchantments();
+        NBTTagList enchantmentNBT = checkStored && nmsStack.getItem() == Items.ENCHANTED_BOOK ? ItemEnchantedBook.d(nmsStack) : nmsStack.getEnchantments();
 
         for (NBTBase base : enchantmentNBT) {
             NBTTagCompound compound = (NBTTagCompound) base;

--- a/eco-core/core-nms/v1_16_R3/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R3/FastGetEnchants.java
+++ b/eco-core/core-nms/v1_16_R3/src/main/java/com/willfp/ecoenchants/proxy/v1_16_R3/FastGetEnchants.java
@@ -1,6 +1,8 @@
 package com.willfp.ecoenchants.proxy.v1_16_R3;
 
 import com.willfp.ecoenchants.proxy.proxies.FastGetEnchantsProxy;
+import net.minecraft.server.v1_16_R3.Items;
+import net.minecraft.server.v1_16_R3.ItemEnchantedBook;
 import net.minecraft.server.v1_16_R3.NBTBase;
 import net.minecraft.server.v1_16_R3.NBTTagCompound;
 import net.minecraft.server.v1_16_R3.NBTTagList;
@@ -15,9 +17,9 @@ import java.util.Map;
 
 public final class FastGetEnchants implements FastGetEnchantsProxy {
     @Override
-    public Map<Enchantment, Integer> getEnchantmentsOnItem(@NotNull final ItemStack itemStack) {
+    public Map<Enchantment, Integer> getEnchantmentsOnItem(@NotNull final ItemStack itemStack, boolean checkStored) {
         net.minecraft.server.v1_16_R3.ItemStack nmsStack = CraftItemStack.asNMSCopy(itemStack);
-        NBTTagList enchantmentNBT = nmsStack.getEnchantments();
+        NBTTagList enchantmentNBT = checkStored && nmsStack.getItem() == Items.ENCHANTED_BOOK ? ItemEnchantedBook.d(nmsStack) : nmsStack.getEnchantments();
         HashMap<Enchantment, Integer> foundEnchantments = new HashMap<>();
 
         for (NBTBase base : enchantmentNBT) {
@@ -35,9 +37,10 @@ public final class FastGetEnchants implements FastGetEnchantsProxy {
 
     @Override
     public int getLevelOnItem(@NotNull final ItemStack itemStack,
-                              @NotNull final Enchantment enchantment) {
+                              @NotNull final Enchantment enchantment,
+                              boolean checkStored) {
         net.minecraft.server.v1_16_R3.ItemStack nmsStack = CraftItemStack.asNMSCopy(itemStack);
-        NBTTagList enchantmentNBT = nmsStack.getEnchantments();
+        NBTTagList enchantmentNBT = checkStored && nmsStack.getItem() == Items.ENCHANTED_BOOK ? ItemEnchantedBook.d(nmsStack) : nmsStack.getEnchantments();
 
         for (NBTBase base : enchantmentNBT) {
             NBTTagCompound compound = (NBTTagCompound) base;

--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/display/EnchantDisplay.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/display/EnchantDisplay.java
@@ -158,7 +158,7 @@ public class EnchantDisplay extends DisplayModule {
             String name = EnchantmentCache.getEntry(enchantment).getName();
 
             if (!(enchantment.getMaxLevel() == 1 && level == 1)) {
-                if (options.getNumbersOptions().isUseNumerals() && ProxyUtils.getProxy(FastGetEnchantsProxy.class).getLevelOnItem(itemStack, enchantment) < options.getNumbersOptions().getThreshold()) {
+                if (options.getNumbersOptions().isUseNumerals() && ProxyUtils.getProxy(FastGetEnchantsProxy.class).getLevelOnItem(itemStack, enchantment, true) < options.getNumbersOptions().getThreshold()) {
                     name += " " + NumberUtils.toNumeral(level);
                 } else {
                     name += " " + level;

--- a/eco-core/core-proxy/src/main/java/com/willfp/ecoenchants/proxy/proxies/FastGetEnchantsProxy.java
+++ b/eco-core/core-proxy/src/main/java/com/willfp/ecoenchants/proxy/proxies/FastGetEnchantsProxy.java
@@ -8,13 +8,25 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Map;
 
 public interface FastGetEnchantsProxy extends AbstractProxy {
+
     /**
      * Get all enchantments on an {@link ItemStack}.
      *
      * @param itemStack The item to query.
      * @return A map of all enchantments, where the value represents the level present.
      */
-    Map<Enchantment, Integer> getEnchantmentsOnItem(@NotNull ItemStack itemStack);
+    default Map<Enchantment, Integer> getEnchantmentsOnItem(@NotNull ItemStack itemStack) {
+        return getEnchantmentsOnItem(itemStack, false);
+    }
+
+    /**
+     * Get all enchantments on an {@link ItemStack}.
+     *
+     * @param itemStack The item to query.
+     * @param checkStored Check stored enchantments in the enchanted book if true.
+     * @return A map of all enchantments, where the value represents the level present.
+     */
+    Map<Enchantment, Integer> getEnchantmentsOnItem(@NotNull ItemStack itemStack, boolean checkStored);
 
     /**
      * Get the level of a specified enchantment on an item.
@@ -23,6 +35,20 @@ public interface FastGetEnchantsProxy extends AbstractProxy {
      * @param enchantment The enchantment to query.
      * @return The level found, or 0 if not present.
      */
+    default int getLevelOnItem(@NotNull ItemStack itemStack,
+                                @NotNull Enchantment enchantment) {
+        return getLevelOnItem(itemStack, enchantment, false);
+    }
+
+    /**
+     * Get the level of a specified enchantment on an item.
+     *
+     * @param itemStack   The item to query.
+     * @param enchantment The enchantment to query.
+     * @param checkStored Check stored enchantments in the enchanted book if true.
+     * @return The level found, or 0 if not present.
+     */
     int getLevelOnItem(@NotNull ItemStack itemStack,
-                       @NotNull Enchantment enchantment);
+                       @NotNull Enchantment enchantment,
+                       boolean checkStored);
 }


### PR DESCRIPTION
FastGetEnchants cannot get enchantments for an enchanted book. This, for example, results in the EnchantDisplay being unable to get the enchantment level to check the numerals display threshold.