### PR TITLE
Fixes some bugs

### DIFF
--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/normal/Necrotic.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/normal/Necrotic.java
@@ -55,6 +55,10 @@ public class Necrotic extends EcoEnchant {
             return;
         }
 
+        if (!event.getEntity().getMetadata("eco-target").isEmpty()) {
+            return;
+        }
+
         ItemStack item = new ItemStack(Material.WITHER_SKELETON_SKULL, 1);
 
         new DropQueue(player)

--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/special/Soulbound.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/special/Soulbound.java
@@ -5,7 +5,7 @@ import com.willfp.ecoenchants.enchantments.EcoEnchants;
 import com.willfp.ecoenchants.enchantments.meta.EnchantmentType;
 import com.willfp.ecoenchants.enchantments.util.EnchantChecks;
 import com.willfp.ecoenchants.enchantments.util.EnchantmentUtils;
-import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -97,9 +97,10 @@ public class Soulbound extends EcoEnchant {
         player.setMetadata("soulbound-items", this.getPlugin().getMetadataValueFactory().create(soulboundItems));
     }
 
-    public boolean hasEmptyInventory(@NotNull final Player player) {
+    public boolean hasSoulboundItems(@NotNull final Player player) {
+        final NamespacedKey soulbound = this.getPlugin().getNamespacedKeyFactory().create("soulbound");
         for (ItemStack itemStack : player.getInventory().getContents()) {
-            if (itemStack != null && itemStack.getType() != Material.AIR) {
+            if (itemStack != null && itemStack.getItemMeta().getPersistentDataContainer().has(soulbound, PersistentDataType.INTEGER)) {
                 return false;
             }
         }
@@ -111,7 +112,7 @@ public class Soulbound extends EcoEnchant {
         Player player = event.getPlayer();
 
         this.getPlugin().getScheduler().runLater(() -> {
-            if (!hasEmptyInventory(player)) {
+            if (!hasSoulboundItems(player)) {
                 return;
             }
 
@@ -142,6 +143,7 @@ public class Soulbound extends EcoEnchant {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onDeath(@NotNull final PlayerDeathEvent event) {
-        event.getDrops().removeIf(itemStack -> itemStack.getItemMeta().getPersistentDataContainer().has(this.getPlugin().getNamespacedKeyFactory().create("soulbound"), PersistentDataType.INTEGER));
+        final NamespacedKey soulbound = this.getPlugin().getNamespacedKeyFactory().create("soulbound");
+        event.getDrops().removeIf(itemStack -> itemStack.getItemMeta().getPersistentDataContainer().has(soulbound, PersistentDataType.INTEGER));
     }
 }

--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/special/Soulbound.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/special/Soulbound.java
@@ -111,7 +111,7 @@ public class Soulbound extends EcoEnchant {
     public void onSoulboundRespawn(@NotNull final PlayerRespawnEvent event) {
         Player player = event.getPlayer();
 
-        this.getPlugin().getScheduler().runLater(() -> {
+        this.getPlugin().getScheduler().run(() -> {
             if (!hasSoulboundItems(player)) {
                 return;
             }
@@ -138,7 +138,7 @@ public class Soulbound extends EcoEnchant {
             }
 
             player.removeMetadata("soulbound-items", this.getPlugin());
-        }, 1);
+        });
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)


### PR DESCRIPTION
Bug 1: Fixed Necrotic bug where Necrotic can cause the wither skeletons summoned by Mortality to drop wither skulls

Bug 2: Fixed Soulbound bug where the soulbound items completely disappear after respawn

There are some cases where the player's inventory is not empty right after respawning. For example, ItemsAdder gives a death map right after the player respawns. In this case, EcoEnchants wouldn't give back soulbound items to the player because the logic was checking whether the player has empty inventory:

https://github.com/Auxilor/EcoEnchants/blob/4e1fefdb3a7dec0dd809276ef210fc512f5d0d87/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/special/Soulbound.java#L114

causing the items just disappeared.

I fix this by checking if there is any soulbound items right after respawning, instead of simply checking whether the player's inventory is empty or not.

More robust logic to handle such case is expected. My solution is just a workaround.