### PR TITLE
Fixed artifacts not working with 1.17 blocks.

### DIFF
--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/angerartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/angerartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/ashartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/ashartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/cloudsartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/cloudsartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/copperartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/copperartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/crimsonartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/crimsonartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/damageartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/damageartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/dragonartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/dragonartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/dustartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/dustartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/emeraldartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/emeraldartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/enchantmentartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/enchantmentartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/endartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/endartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/fireartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/fireartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/glowartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/glowartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/heartartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/heartartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/honeyartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/honeyartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/inkartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/inkartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/lavaartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/lavaartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/lightartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/lightartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/limeartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/limeartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/magicartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/magicartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/magmaartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/magmaartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/musicartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/musicartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/nautilusartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/nautilusartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/netherartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/netherartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/rainartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/rainartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/redstoneartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/redstoneartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/skulkartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/skulkartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/slimeartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/slimeartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/smokeartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/smokeartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/snowartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/snowartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/soulartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/soulartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/soulfireartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/soulfireartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/sparkartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/sparkartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/sparkleartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/sparkleartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/sporeartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/sporeartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/sweepartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/sweepartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/tearartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/tearartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/totemartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/totemartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/villagerartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/villagerartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/warpedartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/warpedartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/waterartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/waterartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/waxartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/waxartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/witchartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/witchartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/enchants/artifact/zapartifact.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/artifact/zapartifact.yml
@@ -10,7 +10,7 @@ obtaining:
   table: true
   villager: true
   loot: true
-  rarity: epic
+  rarity: artifact
 
 general-config:
   flags: []
@@ -43,10 +43,18 @@ config:
   amount: 10
   on-blocks:
     - diamond_ore
+    - deepslate_diamond_ore
     - gold_ore
+    - deepslate_gold_ore
     - lapis_ore
+    - deepslate_lapis_ore
     - redstone_ore
+    - deepslate_redstone_ore
     - iron_ore
+    - deepslate_iron_ore
     - copper_ore
+    - deepslate_copper_ore
+    - emerald_ore
+    - deepslate_emerald_ore
     - obsidian
     - ancient_debris

--- a/eco-core/core-plugin/src/main/resources/rarity.yml
+++ b/eco-core/core-plugin/src/main/resources/rarity.yml
@@ -66,3 +66,11 @@ rarities:
     custom-color:
       enabled: false
       color: "&4"
+  artifact:
+    table-probability: 5
+    minimum-level: 1
+    villager-probability: 9
+    loot-probability: 5
+    custom-color:
+      enabled: false
+      color: "&8"


### PR DESCRIPTION
Fully tested, everything works just as before on 1.16.5 and 1.17.1, but deepslate ore variants work as expected with 1.17. And the artifact rarity works as expected, lowering the chance to get artifacts so normal enchants are slightly easier to get.