### PR TITLE
Allow other plugin to use event anvil

### DIFF
--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/support/merging/anvil/AnvilListeners.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/support/merging/anvil/AnvilListeners.java
@@ -66,6 +66,10 @@ public class AnvilListeners extends PluginDependent<EcoPlugin> implements Listen
         ItemStack left = event.getInventory().getItem(0);
         ItemStack right = event.getInventory().getItem(1);
         ItemStack out = event.getResult();
+        // Allow other plugin to use event anvil
+        if (out == null) {
+            return;
+        }
         String name = event.getInventory().getRenameText();
 
         if (event.getViewers().isEmpty()) {


### PR DESCRIPTION
If there is another plugin that modifies the anvil's resulting item to null, it is considered the event to be cancelled