### PR TITLE
Fix a bug of "Transfuse" enchantment.

### DIFF
--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/normal/Transfuse.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/normal/Transfuse.java
@@ -39,11 +39,11 @@ public class Transfuse extends EcoEnchant {
             return;
         }
 
-        event.setDropItems(false);
-
         if (!this.getConfig().getStrings(EcoEnchants.CONFIG_LOCATION + "works-on").contains(block.getType().toString().toLowerCase())) {
             return;
         }
+        
+        event.setDropItems(false);
 
         Material material;
         double random = NumberUtils.randFloat(0, 1);


### PR DESCRIPTION
In the latest version, "Transfuse" enchantment has a chance to make some blocks / items that isn't in the `works-on` list to **disappear directly**. 

That's because the "drop item" has been set to `false` before checking if it's in the `work-on` list.

If I break a diamond block or something others with a pickaxe that has "Transfuse" enchantment in survival mode and it passed the chance, the diamond block item will **be deleted directly**.

So I moved `event.setDropItems(false);` down to the position below `if (!this.getConfig().getStrings(EcoEnchants.CONFIG_LOCATION + "works-on").contains(block.getType().toString().toLowerCase()))` to let the item not be deleted if it is not in the `works-on` list.
