### PR TITLE
Some Tornado workarounding

### DIFF
--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/normal/Tornado.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/normal/Tornado.java
@@ -1,9 +1,11 @@
 package com.willfp.ecoenchants.enchantments.ecoenchants.normal;
 
+import com.willfp.eco.core.integrations.anticheat.AnticheatManager;
 import com.willfp.ecoenchants.enchantments.EcoEnchant;
 import com.willfp.ecoenchants.enchantments.EcoEnchants;
 import com.willfp.ecoenchants.enchantments.meta.EnchantmentType;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
@@ -25,6 +27,12 @@ public class Tornado extends EcoEnchant {
 
         Vector toAdd = new Vector(0, yVelocity, 0);
 
-        this.getPlugin().getScheduler().runLater(() -> victim.setVelocity(victim.getVelocity().clone().add(toAdd)), 1);
+        this.getPlugin().getScheduler().runLater(() -> {
+            if (victim instanceof Player player) {
+                AnticheatManager.exemptPlayer(player);
+                this.getPlugin().getScheduler().runLater(() -> AnticheatManager.unexemptPlayer(player), this.getConfig().getInt("time-to-exempt"));
+            }
+            victim.setVelocity(victim.getVelocity().clone().add(toAdd));
+        }, 1);
     }
 }

--- a/eco-core/core-plugin/src/main/resources/enchants/normal/tornado.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/normal/tornado.yml
@@ -30,3 +30,4 @@ general-config:
 
 config:
   velocity-per-level: 0.25
+  time-to-exempt: 60 #In ticks. Time to exempt hit player from being detected by your Anti-Cheat for flying (The higher max velocity is - the higher should be this value)


### PR DESCRIPTION
Added time-to-exempt config option for Tornado enchantment and started exempting players that were hit by Tornado from being detectedf by AntiCheats.