### PR TITLE
fix: hunger curse config

### DIFF
--- a/eco-core/core-plugin/src/main/resources/enchants/curse/hungercurse.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/curse/hungercurse.yml
@@ -25,4 +25,4 @@ general-config:
     - sating
 
 config:
-# No config is available for this enchantment
+  times-more-hunger: 2


### PR DESCRIPTION
As specified [here](https://github.com/Auxilor/EcoEnchants/blob/master/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/curse/HungerCurse.java#L48), this enchant need to be configured.
Otherwise delta variable always be zero, and players with this curse never be hunger