### PR TITLE
fix: arraylist index out of bounds

### DIFF
--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/command/CommandRandomenchant.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/command/CommandRandomenchant.java
@@ -40,8 +40,10 @@ public class CommandRandomenchant extends Subcommand {
 
             if ((args.isEmpty() && sender instanceof Player) || !sender.hasPermission("ecoenchants.command.randomenchant.others")) {
                 player = (Player) sender;
-            } else {
+            } else if (!args.isEmpty()) {
                 player = Bukkit.getServer().getPlayer(args.get(0));
+            } else {
+                player = null
             }
 
             if (player == null) {

--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/command/CommandRandomenchant.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/command/CommandRandomenchant.java
@@ -43,7 +43,7 @@ public class CommandRandomenchant extends Subcommand {
             } else if (!args.isEmpty()) {
                 player = Bukkit.getServer().getPlayer(args.get(0));
             } else {
-                player = null
+                player = null;
             }
 
             if (player == null) {


### PR DESCRIPTION
fix: execute `ecoenchants randomenchant` in the console will cause this exception:

```
org.bukkit.command.CommandException: Unhandled exception executing command 'ecoenchants' in plugin EcoEnchants v8.14.23
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[patched_1.16.5.jar:git-Paper-790]
        at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:159) ~[patched_1.16.5.jar:git-Paper-790]
        at org.bukkit.craftbukkit.v1_16_R3.CraftServer.dispatchCommand(CraftServer.java:826) ~[patched_1.16.5.jar:git-Paper-790]
        at org.bukkit.craftbukkit.v1_16_R3.CraftServer.dispatchServerCommand(CraftServer.java:788) ~[patched_1.16.5.jar:git-Paper-790]
        at net.minecraft.server.v1_16_R3.DedicatedServer.handleCommandQueue(DedicatedServer.java:470) ~[patched_1.16.5.jar:git-Paper-790]
        at net.minecraft.server.v1_16_R3.DedicatedServer.b(DedicatedServer.java:437) ~[patched_1.16.5.jar:git-Paper-790]
        at net.minecraft.server.v1_16_R3.MinecraftServer.a(MinecraftServer.java:1347) ~[patched_1.16.5.jar:git-Paper-790]
        at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:1135) ~[patched_1.16.5.jar:git-Paper-790]
        at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:291) ~[patched_1.16.5.jar:git-Paper-790]
        at java.lang.Thread.run(Thread.java:831) [?:?]
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
        at java.util.Arrays$ArrayList.get(Arrays.java:4164) ~[?:?]
        at com.willfp.ecoenchants.command.CommandRandomenchant.lambda$getHandler$1(CommandRandomenchant.java:44) ~[?:?]
        at com.willfp.eco.core.command.impl.HandledCommand.handle(HandledCommand.java:123) ~[?:?]
        at com.willfp.eco.core.command.impl.HandledCommand.handle(HandledCommand.java:116) ~[?:?]
        at com.willfp.eco.core.command.impl.PluginCommand.onCommand(PluginCommand.java:68) ~[?:?]
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[patched_1.16.5.jar:git-Paper-790]
        ... 9 more
```