### PR TITLE
Create lore prefix and suffix for enchanted items

### DIFF
--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/display/EnchantDisplay.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/display/EnchantDisplay.java
@@ -12,6 +12,7 @@ import com.willfp.ecoenchants.enchantments.EcoEnchant;
 import com.willfp.ecoenchants.enchantments.meta.EnchantmentTarget;
 import com.willfp.ecoenchants.enchantments.util.ItemConversionOptions;
 import lombok.Getter;
+import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -174,6 +175,13 @@ public class EnchantDisplay extends DisplayModule {
                 for (Map.Entry<Enchantment, Integer> entry : enchantments.entrySet()) {
                     lore.addAll(EnchantmentCache.getEntry(entry.getKey()).getDescription(entry.getValue()));
                 }
+            }
+        }
+
+        if (itemStack.getType() != Material.ENCHANTED_BOOK) {
+            if (!enchantments.isEmpty()) {
+                lore.addAll(0, options.getLorePrefix());
+                lore.addAll(options.getLoreSuffix());
             }
         }
 

--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/display/options/DisplayOptions.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/display/options/DisplayOptions.java
@@ -119,8 +119,8 @@ public class DisplayOptions extends PluginDependent<EcoPlugin> {
         requireTarget = this.getPlugin().getConfigYml().getBool("lore.require-target");
         aboveLore = this.getPlugin().getConfigYml().getBool("lore.above-other-lore");
 
-        lorePrefix = this.getPlugin().getConfigYml().getStrings("lore.prefix").stream().map(s -> Display.PREFIX + StringUtils.format(s, StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)).collect(Collectors.toList());
-        loreSuffix = this.getPlugin().getConfigYml().getStrings("lore.suffix").stream().map(s -> Display.PREFIX + StringUtils.format(s, StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)).collect(Collectors.toList());
+        lorePrefix = this.getPlugin().getConfigYml().getFormattedStrings("lore.prefix").stream().map(s -> Display.PREFIX + s).collect(Collectors.toList());
+        loreSuffix = this.getPlugin().getConfigYml().getFormattedStrings("lore.suffix").stream().map(s -> Display.PREFIX + s).collect(Collectors.toList());
 
         boolean byType = this.getPlugin().getConfigYml().getBool("lore.sort-by-type");
         boolean byLength = this.getPlugin().getConfigYml().getBool("lore.sort-by-length");

--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/display/options/DisplayOptions.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/display/options/DisplayOptions.java
@@ -2,6 +2,8 @@ package com.willfp.ecoenchants.display.options;
 
 import com.willfp.eco.core.EcoPlugin;
 import com.willfp.eco.core.PluginDependent;
+import com.willfp.eco.core.display.Display;
+import com.willfp.eco.util.StringUtils;
 import com.willfp.ecoenchants.display.options.sorting.EnchantmentSorter;
 import com.willfp.ecoenchants.display.options.sorting.SortParameters;
 import com.willfp.ecoenchants.display.options.sorting.SorterManager;
@@ -11,11 +13,7 @@ import lombok.Getter;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class DisplayOptions extends PluginDependent<EcoPlugin> {
@@ -73,6 +71,17 @@ public class DisplayOptions extends PluginDependent<EcoPlugin> {
     private boolean aboveLore = true;
 
     /**
+     * Lore prefix (above enchantments)
+     */
+    @Getter
+    private List<String> lorePrefix;
+    /**
+     * Lore suffix (below enchantments)
+     */
+    @Getter
+    private List<String> loreSuffix;
+
+    /**
      * Instantiate new display options.
      *
      * @param plugin EcoEnchants.
@@ -109,6 +118,9 @@ public class DisplayOptions extends PluginDependent<EcoPlugin> {
 
         requireTarget = this.getPlugin().getConfigYml().getBool("lore.require-target");
         aboveLore = this.getPlugin().getConfigYml().getBool("lore.above-other-lore");
+
+        lorePrefix = this.getPlugin().getConfigYml().getStrings("lore.prefix").stream().map(s -> Display.PREFIX + StringUtils.format(s, StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)).collect(Collectors.toList());
+        loreSuffix = this.getPlugin().getConfigYml().getStrings("lore.suffix").stream().map(s -> Display.PREFIX + StringUtils.format(s, StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)).collect(Collectors.toList());
 
         boolean byType = this.getPlugin().getConfigYml().getBool("lore.sort-by-type");
         boolean byLength = this.getPlugin().getConfigYml().getBool("lore.sort-by-length");

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -72,6 +72,10 @@ lore:
     after-lines: 9 # Collapse after number of enchantments
     maximum-per-line: 2 # Maximum number of enchantments to have in 1 line
 
+  prefix: # Lines used above the enchantments
+    - ""
+  suffix: [] # Lines used below the enchantments
+
 enchanting-table:
   enabled: true # Enable EcoEnchants through an enchanting table
   book-times-less-likely: 2 # Times less likely to get an EcoEnchant on a book to balance them out. Don't recommend editing.


### PR DESCRIPTION
(except books because it looks ugly on them and makes no sense)

Here's an image of what it would do:
https://imgur.com/IHqxqvR
And here is the config I used for the above image:
```
  prefix:
    - ""
    - "&7&m|            &7[&b Enchants &7]&7&m             |&r"
    - ""
  suffix: []