### PR TITLE
Update maven repo for EngineHub

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
         maven { url 'https://repo.spongepowered.org/maven/' }
         maven { url 'https://org.kitteh.pastegg' }
         maven { url 'https://repo.mikeprimm.com/' }
-        maven { url 'https://maven.sk89q.com/repo/' }
+        maven { url 'https://maven.enginehub.org/repo/' }
         maven { url 'https://github.com/factions-site/repo/raw/public/' }
         maven { url 'https://mvn.lumine.io/repository/maven-public/' }
     }


### PR DESCRIPTION
Small PR, however, the maven repo for EngineHub has switched from `https://maven.sk89q.com/repo/` to `https://maven.enginehub.org/repo/`

It appears that sk89q is down, which caused problems for me building the project.

https://i.imgur.com/KzGaN56.png