### PR TITLE
Unsafe velocity fix

### DIFF
--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/normal/Launch.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/normal/Launch.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 public class Launch extends EcoEnchant {
@@ -55,11 +56,12 @@ public class Launch extends EcoEnchant {
         int level = EnchantChecks.getChestplateLevel(player, this);
         double multiplier = this.getConfig().getDouble(EcoEnchants.CONFIG_LOCATION + "multiplier");
         double boost = 1 + (multiplier * level);
+        Vector vector = player.getVelocity().multiply(boost);
 
-        if (VelocityChecks.isUnsafeVelocity(player.getVelocity().multiply(boost))) {
+        if (VelocityChecks.isUnsafeVelocity(vector)) {
             return;
         }
 
-        this.getPlugin().getScheduler().run(() -> player.setVelocity(player.getVelocity().multiply(boost)));
+        this.getPlugin().getScheduler().run(() -> player.setVelocity(vector));
     }
 }

--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/normal/Launch.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/ecoenchants/normal/Launch.java
@@ -4,6 +4,7 @@ import com.willfp.ecoenchants.enchantments.EcoEnchant;
 import com.willfp.ecoenchants.enchantments.EcoEnchants;
 import com.willfp.ecoenchants.enchantments.meta.EnchantmentType;
 import com.willfp.ecoenchants.enchantments.util.EnchantChecks;
+import com.willfp.ecoenchants.enchantments.util.VelocityChecks;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -54,6 +55,10 @@ public class Launch extends EcoEnchant {
         int level = EnchantChecks.getChestplateLevel(player, this);
         double multiplier = this.getConfig().getDouble(EcoEnchants.CONFIG_LOCATION + "multiplier");
         double boost = 1 + (multiplier * level);
+
+        if (VelocityChecks.isUnsafeVelocity(player.getVelocity().multiply(boost))) {
+            return;
+        }
 
         this.getPlugin().getScheduler().run(() -> player.setVelocity(player.getVelocity().multiply(boost)));
     }

--- a/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/util/VelocityChecks.java
+++ b/eco-core/core-plugin/src/main/java/com/willfp/ecoenchants/enchantments/util/VelocityChecks.java
@@ -1,0 +1,22 @@
+package com.willfp.ecoenchants.enchantments.util;
+
+import org.bukkit.util.Vector;
+
+public class VelocityChecks {
+    /**
+     * Checks to see if the velocity is unsafe. This is taken from Papers 0054-Add-velocity-warnings.patch
+     * @param vel
+     * @return
+     */
+    public static boolean isUnsafeVelocity(Vector vel) {
+        final double x = vel.getX();
+        final double y = vel.getY();
+        final double z = vel.getZ();
+
+        if (x > 4 || x < -4 || y > 4 || y < -4 || z > 4 || z < -4) {
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Applies a fix for the Launch enchantment, which could cause a player to have an "unsafe" amount of velocity, likely crashing the server in the process as mentioned in #263 and on the discord. 

This takes the same formula that Paper uses in its patch. Due to they have it as a private method, I am unable to use it directly from Paper, leading to us having new util. 