### PR TITLE
Add an option to disable display module completely

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/EcoEnchantsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/EcoEnchantsPlugin.kt
@@ -86,7 +86,10 @@ class EcoEnchantsPlugin : LibReforgePlugin() {
         )
     }
 
-    override fun createDisplayModule(): DisplayModule {
+    override fun createDisplayModule(): DisplayModule? {
+        if (configYml.getBoolOrNull("display.enabled") == false) {
+            return null
+        }
         return EnchantDisplay(this)
     }
 

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -31,6 +31,8 @@ anvil:
 
 # Options for how enchantments are displayed on items
 display:
+  enabled: true # Setting this to false will disable all visual item modifications
+
   numerals:
     enabled: true # If numerals should be used for the enchantment levels
     threshold: 10 # Above this, numbers will be used instead of numerals


### PR DESCRIPTION
This PR adds an config option that allows to disable plugin's display module completely.

This feature may be needed when you have some other plugin handling visual part and only want to use EcoEnchants for enchantments or some other features 