### PR TITLE
Add give random book command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ allprojects {
 
         compileOnly 'org.jetbrains:annotations:23.0.0'
         compileOnly 'com.github.ben-manes.caffeine:caffeine:3.0.6'
+        compileOnly 'org.spigotmc:spigot-api:1.19.2-R0.1-SNAPSHOT'
+        compileOnly 'com.mojang:datafixerupper:5.0.28'
 
         compileOnly 'org.jetbrains.kotlin:kotlin-stdlib:1.7.10'
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/commands/CommandEcoEnchants.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/commands/CommandEcoEnchants.kt
@@ -14,5 +14,7 @@ class CommandEcoEnchants(plugin: EcoPlugin) : PluginCommand(plugin, "ecoenchants
     init {
         addSubcommand(CommandReload(plugin))
             .addSubcommand(CommandToggleDescriptions(plugin))
+        addSubcommand(CommandReload(plugin))
+            .addSubcommand(CommandGiveRandomBook(plugin))
     }
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/commands/CommandGiveRandomBook.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/commands/CommandGiveRandomBook.kt
@@ -5,11 +5,13 @@ import com.willfp.eco.core.command.impl.Subcommand
 import com.willfp.eco.core.config.updating.ConfigUpdater
 import com.willfp.eco.core.items.builder.EnchantedBookBuilder
 import com.willfp.eco.util.NumberUtils
-import com.willfp.ecoenchants.enchants.EcoEnchants
+import com.willfp.eco.util.toNiceString
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer
 import org.bukkit.Bukkit
-import org.bukkit.ChatColor
 import org.bukkit.command.CommandSender
 import org.bukkit.enchantments.Enchantment
+import org.bukkit.entity.Player
 import org.bukkit.util.StringUtil
 import java.util.*
 import java.util.stream.Collectors.toList
@@ -75,16 +77,21 @@ class CommandGiveRandomBook(plugin: EcoPlugin) : Subcommand(
         }
 
         var message = plugin.langYml.getMessage("gave-random-book")
+        //Player replacement doesn't work for some reason
+        message = message.replace(
+            "%player%",
+            player.name.toString() + "§r"
+        )
         message = message.replace(
             "%enchantment%",
-            enchantment.displayName(level).toString() + "§r"
+            PlainTextComponentSerializer.plainText().serialize(enchantment.displayName(level)) + "§r"
         )
         sender.sendMessage(message)
 
         var message2 = plugin.langYml.getMessage("received-random-book")
         message2 = message2.replace(
             "%enchantment%",
-            enchantment.displayName(level).toString() + "§r"
+            PlainTextComponentSerializer.plainText().serialize(enchantment.displayName(level)) + "§r"
         )
         player.sendMessage(message2)
     }
@@ -92,7 +99,8 @@ class CommandGiveRandomBook(plugin: EcoPlugin) : Subcommand(
     override fun tabComplete( sender: CommandSender, args: List<String>): List<String> {
         val completions = mutableListOf<String>()
 
-        val playerNames = EcoEnchants.values().mapNotNull { ChatColor.stripColor(it.displayName) }
+        //Create a list of online players for auto-completion
+        val playerNames = Bukkit.getServer().onlinePlayers.stream().map(Player::getName).collect(toList())
 
         if (args.isEmpty()) {
             // Currently, this case is not ever reached

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/commands/CommandGiveRandomBook.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/commands/CommandGiveRandomBook.kt
@@ -1,0 +1,149 @@
+package com.willfp.ecoenchants.commands
+
+import com.willfp.eco.core.EcoPlugin
+import com.willfp.eco.core.command.impl.Subcommand
+import com.willfp.eco.core.config.updating.ConfigUpdater
+import com.willfp.eco.core.items.builder.EnchantedBookBuilder
+import com.willfp.eco.util.NumberUtils
+import com.willfp.ecoenchants.enchants.EcoEnchants
+import org.bukkit.Bukkit
+import org.bukkit.ChatColor
+import org.bukkit.command.CommandSender
+import org.bukkit.enchantments.Enchantment
+import org.bukkit.util.StringUtil
+import java.util.*
+import java.util.stream.Collectors.toList
+
+class CommandGiveRandomBook(plugin: EcoPlugin) : Subcommand(
+    plugin,
+    "giverandombook",
+    "ecoenchants.command.giverandombook",
+    false
+) {
+
+    override fun onExecute(
+        sender: CommandSender,
+        args: List<String>
+    ) {
+
+        if (args.isEmpty()) {
+            sender.sendMessage(plugin.langYml.getMessage("requires-player"))
+            return
+        }
+
+        val player = Bukkit.getServer().getPlayer(args[0])
+
+        val rarity: com.willfp.ecoenchants.rarity.EnchantmentRarity? =
+            if (args.size >= 2) com.willfp.ecoenchants.rarity.EnchantmentRarities.getByID(
+                args[1].lowercase(Locale.getDefault())
+            ) else null
+
+        val type: com.willfp.ecoenchants.type.EnchantmentType? =
+            if (rarity == null && args.size >= 2) com.willfp.ecoenchants.type.EnchantmentTypes.getByID(
+                args[1].lowercase(Locale.getDefault())
+            ) else null
+
+        if (player == null) {
+            sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
+            return
+        }
+
+        val allowed = Arrays.stream(Enchantment.values()).filter { enchantment: Enchantment ->
+            if (enchantment is com.willfp.ecoenchants.enchants.EcoEnchant) {
+                if (rarity != null) {
+                    return@filter enchantment.rarity == rarity
+                }
+                if (type != null) {
+                    return@filter enchantment.type == type
+                }
+                return@filter true
+            }
+            false
+        }.collect(toList())
+
+        val enchantment = allowed[NumberUtils.randInt(0, allowed.size - 1)]
+        val level = NumberUtils.randInt(1, enchantment.maxLevel)
+        val itemStack = EnchantedBookBuilder()
+            .addStoredEnchantment(enchantment, level)
+            .build()
+
+        //Add the item to the player's inventory if there is space, otherwise drop it at their feet
+        if (player.inventory.firstEmpty() == -1) {
+            player.world.dropItem(player.location, itemStack)
+        } else {
+            player.inventory.addItem(itemStack)
+        }
+
+        var message = plugin.langYml.getMessage("gave-random-book")
+        message = message.replace(
+            "%enchantment%",
+            enchantment.displayName(level).toString() + "§r"
+        )
+        sender.sendMessage(message)
+
+        var message2 = plugin.langYml.getMessage("received-random-book")
+        message2 = message2.replace(
+            "%enchantment%",
+            enchantment.displayName(level).toString() + "§r"
+        )
+        player.sendMessage(message2)
+    }
+
+    override fun tabComplete( sender: CommandSender, args: List<String>): List<String> {
+        val completions = mutableListOf<String>()
+
+        val playerNames = EcoEnchants.values().mapNotNull { ChatColor.stripColor(it.displayName) }
+
+        if (args.isEmpty()) {
+            // Currently, this case is not ever reached
+            return playerNames
+        }
+
+        if (args.size == 1) {
+            StringUtil.copyPartialMatches( args[0], playerNames, completions )
+        }
+
+        if (args.size == 2) {
+            StringUtil.copyPartialMatches(
+                java.lang.String.join(
+                    " ",
+                    args[1]
+                ), RARITY_NAMES, completions
+            )
+            StringUtil.copyPartialMatches(
+                java.lang.String.join(
+                    " ",
+                    args[1]
+                ), TYPE_NAMES, completions
+            )
+        }
+
+        completions.sort()
+        return completions
+    }
+
+    companion object {
+        /**
+         * Cache the rarities for tab completion
+         */
+        private var RARITY_NAMES: List<String> = com.willfp.ecoenchants.rarity.EnchantmentRarities.values().map { it.id }
+
+        /**
+         * Cache the type names for tab completion
+         */
+        private var TYPE_NAMES: List<String> = com.willfp.ecoenchants.type.EnchantmentTypes.values().map { it.id }
+
+
+        /**
+         * Called on /reload.
+         */
+        @ConfigUpdater
+        fun reload() {
+            //Clear and re-cache rarities
+            RARITY_NAMES = com.willfp.ecoenchants.rarity.EnchantmentRarities.values().map { it.id }
+
+            //Clear and re-cache types
+            TYPE_NAMES = com.willfp.ecoenchants.type.EnchantmentTypes.values().map { it.id }
+        }
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/commands/CommandGiveRandomBook.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/commands/CommandGiveRandomBook.kt
@@ -21,6 +21,16 @@ class CommandGiveRandomBook(plugin: EcoPlugin) : Subcommand(
     false
 ) {
 
+    /**
+     * Cache the rarities for tab completion
+     */
+    private var RARITY_NAMES: List<String> = com.willfp.ecoenchants.rarity.EnchantmentRarities.keySet().toList()
+
+    /**
+     * Cache the type names for tab completion
+     */
+    private var TYPE_NAMES: List<String> = com.willfp.ecoenchants.type.EnchantmentTypes.keySet().toList()
+
     override fun onExecute(
         sender: CommandSender,
         args: List<String>
@@ -137,30 +147,5 @@ class CommandGiveRandomBook(plugin: EcoPlugin) : Subcommand(
 
         completions.sort()
         return completions
-    }
-
-    companion object {
-        /**
-         * Cache the rarities for tab completion
-         */
-        private var RARITY_NAMES: List<String> = com.willfp.ecoenchants.rarity.EnchantmentRarities.values().map { it.id }
-
-        /**
-         * Cache the type names for tab completion
-         */
-        private var TYPE_NAMES: List<String> = com.willfp.ecoenchants.type.EnchantmentTypes.values().map { it.id }
-
-
-        /**
-         * Called on /reload.
-         */
-        @ConfigUpdater
-        fun reload() {
-            //Clear and re-cache rarities
-            RARITY_NAMES = com.willfp.ecoenchants.rarity.EnchantmentRarities.values().map { it.id }
-
-            //Clear and re-cache types
-            TYPE_NAMES = com.willfp.ecoenchants.type.EnchantmentTypes.values().map { it.id }
-        }
     }
 }

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -12,8 +12,9 @@ messages:
   enabled-descriptions: "&fYou have successfully &aenabled &fenchantment descriptions!"
   disabled-descriptions: "&fYou have successfully &cdisabled &fenchantment descriptions!"
   descriptions-disabled: "&cEnchantment descriptions are disabled on this server."
-  gave-random-book: "&fYou have successfully &agiven &f%player% a %enchantment% book!"
-  received-random-book: "&fYou have received a %enchantment% book!"
+  gave-random-book: "&aYou have successfully given &c%targetplayer% &aa &6%enchantment% &abook!"
+  received-random-book: "&aYou have received a &6%enchantment% &abook!"
+  no-enchantments: "&cNo enchantments available for this rarity/type!"
   not-found: "&cCannot find an enchantment matching name: &f%name%."
   missing-enchant: "&cYou must specify an enchantment!"
 

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -13,7 +13,7 @@ messages:
   disabled-descriptions: "&fYou have successfully &cdisabled &fenchantment descriptions!"
   descriptions-disabled: "&cEnchantment descriptions are disabled on this server."
   gave-random-book: "&fYou have successfully &agiven &f%player% a %enchantment% book!"
-  received-random-book: "&fYou have received a random book!"
+  received-random-book: "&fYou have received a %enchantment% book!"
   not-found: "&cCannot find an enchantment matching name: &f%name%."
   missing-enchant: "&cYou must specify an enchantment!"
 

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -12,6 +12,8 @@ messages:
   enabled-descriptions: "&fYou have successfully &aenabled &fenchantment descriptions!"
   disabled-descriptions: "&fYou have successfully &cdisabled &fenchantment descriptions!"
   descriptions-disabled: "&cEnchantment descriptions are disabled on this server."
+  gave-random-book: "&fYou have successfully &agiven &f%player% a %enchantment% book!"
+  received-random-book: "&fYou have received a random book!"
   not-found: "&cCannot find an enchantment matching name: &f%name%."
   missing-enchant: "&cYou must specify an enchantment!"
 

--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -46,6 +46,7 @@ permissions:
       ecoenchants.command.ecoenchants: true
       ecoenchants.command.toggledescriptions: true
       ecoenchants.command.enchantinfo: true
+      ecoenchants.command.giverandombook: true
   ecoenchants.anvil.*:
     description: All anvil perks
     default: op
@@ -57,6 +58,9 @@ permissions:
     default: op
   ecoenchants.command.reload:
     description: Allows reloading the config
+    default: op
+  ecoenchants.command.giverandombook:
+    description: Allows the use of /ecoenchants giverandombook.
     default: op
   ecoenchants.command.ecoenchants:
     description: Allows the use of /ecoenchants.


### PR DESCRIPTION
Added a giverandombook command to allow easier migration from other plugins and easier integration with crates/rewards/other loot pools. I tried to mirror the functionality of the 8.x.x command as closely as possible. I've bug tested it pretty well and don't see any other issues at the moment.

`/ecoenchants giverandombook <Player> [rarity/type]`