### PR TITLE
Fix Sculk block break does not drop EXP

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchants/impl/EnchantmentTelekinesis.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchants/impl/EnchantmentTelekinesis.kt
@@ -62,6 +62,10 @@ class EnchantmentTelekinesis(
             val player = event.player
             val block = event.block
 
+            if (!player.hasEnchantActive(enchant)) {
+                return
+            }
+
             if (!AntigriefManager.canBreakBlock(player, block)) {
                 return
             }


### PR DESCRIPTION
This is an issue as seen in https://github.com/Auxilor/EcoEnchants/issues/320, I think this would fix that bug.