### PR TITLE
Fix Soulbound with single-use option

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchants/impl/EnchantmentSoulbound.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchants/impl/EnchantmentSoulbound.kt
@@ -131,7 +131,9 @@ class EnchantmentSoulbound(
             ignoreCancelled = true
         )
         fun preventDroppingSoulboundItems(event: PlayerDeathEvent) {
-            event.drops.removeIf { it.fast().persistentDataContainer.has(soulboundKey, PersistentDataType.INTEGER) }
+            event.drops.removeIf { it.fast().persistentDataContainer.has(soulboundKey, PersistentDataType.INTEGER)
+                    && it.itemMeta.hasEnchant(enchant)
+            }
         }
     }
 }


### PR DESCRIPTION
Problem fixed: Items with the soulbound enchantment are removed after the second death