### PR TITLE
Optimization for users who don't use %active_level%

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/target/EnchantLookup.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/target/EnchantLookup.kt
@@ -3,6 +3,7 @@ package com.willfp.ecoenchants.target
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.willfp.eco.core.fast.fast
 import com.willfp.eco.core.items.HashedItem
+import com.willfp.ecoenchants.EcoEnchantsPlugin
 import com.willfp.ecoenchants.enchants.EcoEnchant
 import com.willfp.ecoenchants.enchants.EcoEnchantLevel
 import com.willfp.ecoenchants.enchants.FoundEcoEnchantLevel
@@ -307,13 +308,17 @@ object EnchantLookup {
 
             // This is such a fucking disgusting way of implementing %active_level%,
             // and it's probably quite slow too.
-            return found.map {
-                val level = it.holder as EcoEnchantLevel
+            return if (EcoEnchantsPlugin.instance.configYml.getBool("internal-placeholders.active-level")) {
+                found.map {
+                    val level = it.holder as EcoEnchantLevel
 
-                ItemProvidedHolder(
-                    FoundEcoEnchantLevel(level, this.getActiveEnchantLevel(level.enchant)),
-                    it.provider
-                )
+                    ItemProvidedHolder(
+                        FoundEcoEnchantLevel(level, this.getActiveEnchantLevel(level.enchant)),
+                        it.provider
+                    )
+                }
+            } else {
+                found
             }
         }
 

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -166,3 +166,7 @@ enchant-gui:
 lore-conversion:
   enabled: false # If lore conversion should be enabled
   aggressive: false # Will convert all items in all inventories when opened, likely to use a lot of performance
+
+#Options for enable or disable placeholders of EcoEnchants
+internal-placeholders:
+  active-level: true # Enable or disable %active_level% placeholder. Can be disabled to save some cpu time, if you don't use this placeholder


### PR DESCRIPTION
Placeholder %active_level% can be enabled or disabled in config.yml.
This commit can save performance by ~60x times of refreshHolder for users, who don't use %active_level% placeholder

with %active_level% enabled time to execute heldEnchantLevels method:
![image](https://github.com/Auxilor/EcoEnchants/assets/62211966/3c95b324-7e88-4271-9c8e-6e168b5b571c)

%active_level% disabled, time to execute heldEnchantLevels method:
![image](https://github.com/Auxilor/EcoEnchants/assets/62211966/39ccfcad-f853-4712-86ca-388234a69e72)
