### PR TITLE
Change Anvil Event priority to work with other plugins

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
@@ -55,7 +55,7 @@ class AnvilSupport(
             ProxyConstants.NMS_VERSION.substring(1) +
             "\$AnvilContainer"
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGH)
     fun onAnvilPrepare(event: PrepareAnvilEvent) {
         val player = event.viewers.getOrNull(0) as? Player ?: return
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
@@ -55,7 +55,6 @@ class AnvilSupport(
             ProxyConstants.NMS_VERSION.substring(1) +
             "\$AnvilContainer"
 
-    @EventHandler(priority = EventPriority.HIGH)
     fun onAnvilPrepare(event: PrepareAnvilEvent) {
         val player = event.viewers.getOrNull(0) as? Player ?: return
 


### PR DESCRIPTION
Currently the set priority of HIGHEST has collisions with other spigot plugins. I recommend to lower the priority to HIGH and leave priority HIGHEST to plugins that modify the mechanics of anvils and want to support EcoEnchants. Thanks!