### PR TITLE
soul_storm not removing hearts

### DIFF
--- a/eco-core/core-plugin/src/main/resources/enchants/soul_storm.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/soul_storm.yml
@@ -27,18 +27,16 @@ effects:
                 - bow_attack
                 - melee_attack
                 - trident_attack
-            - id: bonus_health
-              args:
-                health: -6
           conditions: [ ]
           duration: "(15 + 5 * %level%) * 20"
-
+      - id: give_health
+        args:
+          amount: -6
       - id: play_sound
         args:
           sound: entity_ghast_scream
           pitch: 0.7
           volume: 1
-
     args:
       cooldown: 180
       send_cooldown_message: true


### PR DESCRIPTION
The enchantment was using the effect "bonus_health" to remove hearts, which doesn't work.

Replaced it with give_health and made it go under the chain, not the holder.