### PR TITLE
Fixed exploit for the dynamite enchantment

### DIFF
--- a/eco-core/core-plugin/src/main/resources/enchants/dynamite.yml
+++ b/eco-core/core-plugin/src/main/resources/enchants/dynamite.yml
@@ -36,6 +36,11 @@ effects:
         volume: 1
 
     - id: break_block
+      filters:
+        not_blocks:
+          - obsidian
+          - barrier
+          - bedrock
 
     args:
       cooldown: 60


### PR DESCRIPTION
The chain was only filtering blocks in the mine_radius effect. By doing it this way, the break_block effect could still break obsidian, barrier and bedrock.

I've added a filter to the break_block effect as well, which prevents the exploit. 

Additionally, I've not put the filter under the chain, as this would cause an issue with blocks around a clicked blacklisted block.