### PR TITLE
[FIX] Anvil result overriding to null before any logic

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
@@ -78,9 +78,6 @@ class AnvilSupport(
             val old = left?.clone()
             val right = event.inventory.getItem(1)?.clone()
 
-            event.result = null
-            event.inventory.setItem(2, null)
-
             val result = doMerge(
                 left,
                 right,
@@ -88,16 +85,19 @@ class AnvilSupport(
                 player
             )
 
+            if (result == FAIL) {
+                return@run
+            }
+
+            event.result = null
+            event.inventory.setItem(2, null)
+
             val price = result.xp ?: 0
             val outItem = result.result ?: ItemStack(Material.AIR)
 
             val oldCost = event.inventory.repairCost
 
             val oldLeft = event.inventory.getItem(0)
-
-            if (result == FAIL) {
-                return@run
-            }
 
             if (oldLeft == null || oldLeft.type != outItem.type) {
                 return@run


### PR DESCRIPTION
This change fixes a collision with other plugins that modify the anvil behaviour. Such as Disechantment or CustomAnvil.

The changes are only in the execution steps, there isn't anything that would modify the behaviour of the `AnvilSupport.kt`

Thank you for merging!