### PR TITLE
Update AnvilSupport.kt

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
@@ -264,7 +264,7 @@ class AnvilSupport(
 
         val enchantLevelDiff = abs(leftEnchants.values.sum() - outEnchants.values.sum())
         val xpCost =
-            plugin.configYml.getDouble("anvil.cost-exponent").pow(enchantLevelDiff) * enchantLevelDiff + unitRepairCost
+            enchantLevelDiff.toDouble().pow(plugin.configYml.getDouble("anvil.cost-exponent")) + unitRepairCost
 
         return AnvilResult(left, xpCost.roundToInt())
     }


### PR DESCRIPTION
This PR fixes anvil XP costs by switching to a simpler formula that scales fairly.

Old formula: (0.9^level) * level + 1
Example: Combining level 10 enchants costs (0.9^10)*10 + 1 ≈ 4.3 levels (way too cheap).

New formula: (level^0.9) + 1
Example: Same level 10 enchants now cost 10^0.9 + 1 ≈ 8.9 levels (balanced).

The new version prevents costs from getting too high or too low at later levels. Just set cost-exponent in config (0.8 = easy, 1.0 = vanilla-like, 1.2 = harder).