### PR TITLE
Update AnvilSupport.kt for permanenceCurse

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
@@ -46,6 +46,8 @@ class AnvilSupport(
     /**
      * Map to prevent incrementing cost several times as inventory events are fired 3 times.
      */
+
+
     private val antiRepeat = mutableSetOf<UUID>()
 
     /**
@@ -58,6 +60,17 @@ class AnvilSupport(
     @EventHandler(priority = EventPriority.HIGHEST)
     fun onAnvilPrepare(event: PrepareAnvilEvent) {
         val player = event.viewers.getOrNull(0) as? Player ?: return
+        val permanenceCurse = EcoEnchants.getByID("permanence_curse")
+        val leftItem = event.inventory.getItem(0)
+        val rightItem = event.inventory.getItem(1)
+        if (permanenceCurse != null) {
+            if ((leftItem != null && leftItem.fast().getEnchants(true).containsKey(permanenceCurse.enchantment)) ||
+                (rightItem != null && rightItem.fast().getEnchants(true).containsKey(permanenceCurse.enchantment))) {
+                event.result = null
+                event.inventory.setItem(2, null)
+                return
+            }
+        }
 
         if (this.plugin.getProxy(OpenInventoryProxy::class.java)
                 .getOpenInventory(player)::class.java.toString() == anvilGuiClass
@@ -156,14 +169,6 @@ class AnvilSupport(
         } else {
             ChatColor.stripColor(itemName)
         }.let { if (it.isNullOrEmpty()) left.fast().displayName else it }
-
-        val permanenceCurse = EcoEnchants.getByID("permanence_curse")
-
-        if (permanenceCurse != null) {
-            if (left.fast().getEnchants(true).containsKey(permanenceCurse.enchantment)) {
-                return FAIL
-            }
-        }
 
         if (right == null || right.type == Material.AIR) {
             if (left.fast().displayName == formattedItemName) {


### PR DESCRIPTION
Update permanenceCurse check to synchronous task instead of asynchronous since Bukkit Event is synchronous. 

This PR is intented to fix Anvil behaviour with the Curse of Permanence enchant of EcoEnchants. Without this fix, the curse is bypassable by clicking fast on the result item while renaming since it's appearing temporarily on the client-side. Since the event was cancelled by a sheduler it introduced a delay of approx. 1 tick which was enough to glitch it and drag the item in your inventory. By putting the check just after onPrepareAnvil it now cancel it before so the item appear for less time and you are not able to glitch it anymore preventing the bypass.

Need more testing so compile and if confirmed to work maybe a merge could occur to finally fix this issue present since a long time. Just make sure it don't break other stuff, so use with precautions.