### PR TITLE
Add option to display enchantments below lore

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/display/EnchantDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/display/EnchantDisplay.kt
@@ -128,7 +128,11 @@ class EnchantDisplay(private val plugin: EcoEnchantsPlugin) : DisplayModule(plug
             hse.hideStoredEnchants(fast)
         }
 
-        fast.lore = enchantLore + lore + notMetLines
+        if(plugin.configYml.getBool("display.enchantments-below-lore")) {
+            fast.lore = lore + enchantLore + notMetLines
+        } else {
+            fast.lore = enchantLore + lore + notMetLines
+        }
     }
 
     override fun revert(itemStack: ItemStack) {

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -36,6 +36,8 @@ display:
   # If you disable display, enchantments will not show up on items. Only disable if you are handling display elsewhere.
   # Changing this will require a server restart.
   enabled: true
+  # If enchantments should be displayed on the bottom of the item's lore
+  enchantments-below-lore: false
 
   numerals:
     enabled: true # If numerals should be used for the enchantment levels


### PR DESCRIPTION
When `display.enchantments-below-lore` enabled, enchantment lore is appended after the existing item lore instead of before it.  
If the option is disabled, the original behavior is preserved.