### PR TITLE
Fix anvil bypassing max-repair-cost when clamp-repair-cost is false

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
@@ -150,6 +150,10 @@ class AnvilSupport(
             event.view.maximumRepairCost = maxRepairCost
             event.view.repairCost = if (clampRepairCost) cost.coerceAtMost(maxRepairCost) else cost
 
+            if (!clampRepairCost && maxRepairCost > 0 && cost >= maxRepairCost) {
+                return@run
+            }
+
             event.result = outItem
             event.inventory.setItem(2, outItem)
         }

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -29,7 +29,7 @@ anvil:
   cost-exponent: 0.95 # The exponent for each enchant level to prevent constant "Too Expensive!" problems
   enchant-limit: -1 # The limit for the amount of enchantments on an item (-1 to disable)
   use-rework-penalty: true # If the rework penalty should be applied
-  max-repair-cost: 40 # Override the maximum repair cost (-1 to make it infinite). "Too Expensive" message cannot be removed, but this is purely visual.
+  max-repair-cost: 40 # Override the maximum repair cost (-1 to make it infinite). When clamp-repair-cost is false, exceeding this cost will block the enchantment.
   clamp-repair-cost: true # If the repair cost should be clamped to the maximum repair cost
 
 # Options for how enchantments are displayed on items


### PR DESCRIPTION
## Summary
- When `clamp-repair-cost: false` and the actual cost exceeds `max-repair-cost`, the anvil still places the result item in the output slot, allowing players to take it despite the "Too Expensive!" message
- Added a check before setting the result: if `clampRepairCost` is false, `maxRepairCost > 0`, and `cost >= maxRepairCost`, the result is not set, making "Too Expensive!" actually block the enchantment
- Updated the `max-repair-cost` config comment to reflect the corrected behavior

## Test plan
- [ ] Set `clamp-repair-cost: false` and `max-repair-cost: 39`
- [ ] Attempt an anvil enchantment that costs >= 39 levels
- [ ] Verify "Too Expensive!" is shown and the item cannot be taken
- [ ] Set `clamp-repair-cost: true` and verify enchanting still works normally (cost is clamped)
- [ ] Set `max-repair-cost: -1` and verify no limit is enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)