### PR TITLE
Fix Conflicts not being Displayed Correctly in Enchantinfo

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/EcoEnchants.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/EcoEnchants.kt
@@ -18,6 +18,7 @@ import com.willfp.ecoenchants.target.EnchantmentTargets
 import com.willfp.ecoenchants.type.EnchantmentTypes
 import com.willfp.libreforge.loader.LibreforgePlugin
 import com.willfp.libreforge.loader.configs.RegistrableCategory
+import org.bukkit.ChatColor
 
 @Suppress("UNUSED")
 object EcoEnchants : RegistrableCategory<EcoEnchant>("enchant", "enchants") {
@@ -31,7 +32,7 @@ object EcoEnchants : RegistrableCategory<EcoEnchant>("enchant", "enchants") {
         for (enchant in registry.values()) {
             plugin.enchantmentRegisterer.unregister(enchant)
             EnchantRegistrations.removeEnchant(enchant)
-            BY_NAME.remove(enchant.getFormattedName(0))
+            BY_NAME.remove(ChatColor.stripColor(enchant.getFormattedName(0)))
         }
 
         registry.clear()
@@ -95,7 +96,7 @@ object EcoEnchants : RegistrableCategory<EcoEnchant>("enchant", "enchants") {
         // Register delegated versions
         registry.register(enchantment as EcoEnchant)
         @Suppress("DEPRECATION")
-        BY_NAME[org.bukkit.ChatColor.stripColor(enchant.getFormattedName(0))] = enchantment as EcoEnchant
+        BY_NAME[ChatColor.stripColor(enchant.getFormattedName(0))] = enchantment as EcoEnchant
         EnchantRegistrations.registerEnchantments()
     }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/Util.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/Util.kt
@@ -12,6 +12,8 @@ fun Enchantment.wrap(): EcoEnchantLike {
         return this
     }
 
+    EcoEnchants.getByID(this.key.key)?.let { return it }
+
     return ecoEnchantLikes.getOrPut(this.key) {
         VanillaEcoEnchantLike(this, plugin)
     }


### PR DESCRIPTION
- Fixes missing conflict display in /enchantinfo whereby one enchant shows the conflict, while the other one does not.
- Don't know if this is the best way to fix it, should be checked