### PR TITLE
feat: Customisable GUIs

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/EnchantGUI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/EnchantGUI.kt
@@ -31,10 +31,14 @@ import org.bukkit.Material
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemFlag
 import org.bukkit.inventory.ItemStack
+import com.willfp.ecoenchants.rarity.EnchantmentRarities
+import com.willfp.ecoenchants.type.EnchantmentTypes
+import com.willfp.ecoenchants.target.EnchantmentTargets
 import kotlin.math.ceil
 
 object EnchantGUI {
     private lateinit var menu: Menu
+    private var groupMenu: Menu? = null
     private val enchantInfoMenus = Caffeine.newBuilder().build<EcoEnchant, Menu>()
 
     internal fun reload() {
@@ -76,19 +80,52 @@ object EnchantGUI {
 
             onRender { player, menu ->
                 val atCaptive = menu.getCaptiveItem(player, captiveRow, captiveColumn)
-                if (atCaptive.isEcoEmpty || atCaptive == null || atCaptive.type == Material.BOOK) {
-                    menu.setState(player, "enchants", EcoEnchants.values().map { it.enchantment }.sortForDisplay())
+                val hasItem = !atCaptive.isEcoEmpty && atCaptive != null && atCaptive.type != Material.BOOK
+
+                val baseEnchants = if (!hasItem) {
+                    EcoEnchants.values().map { it.enchantment }.sortForDisplay()
                 } else {
-                    menu.setState(
-                        player,
-                        "enchants",
-                        atCaptive.applicableEnchantments.map { it.enchantment }.sortForDisplay()
-                            .subtract(atCaptive.fast().enchants.keys)
-                            .toList()
-                    )
+                    atCaptive.applicableEnchantments.map { it.enchantment }.sortForDisplay()
+                        .subtract(atCaptive.fast().enchants.keys)
+                        .toList()
                 }
 
-                if (menu.getPage(player) > menu.getMaxPage(player)) {
+                // Apply group filter if a groupId is set in menu state
+                val groupId = menu.getState<String>(player, "groupId")
+                val filteredEnchants = if (groupId != null) {
+                    val groupBy = plugin.configYml.getString("enchant-gui.group-by")
+                    baseEnchants.filter { enchantment ->
+                        val wrapped = enchantment.wrap()
+                        when (groupBy) {
+                            "type" -> wrapped.type.id == groupId
+                            "rarity" -> wrapped.enchantmentRarity.id == groupId
+                            "target" -> wrapped is EcoEnchant && wrapped.targets.any { it.id == groupId }
+                            else -> true
+                        }
+                    }
+                } else {
+                    baseEnchants
+                }
+
+                menu.setState(player, "enchants", filteredEnchants)
+
+                // Reset to page 1 when an item is placed or removed from the captive slot
+                val previousHasItem = menu.getState<Boolean>(player, "hasItem") ?: false
+                if (hasItem != previousHasItem) {
+                    menu.setState(player, Page.PAGE_KEY, 1)
+                }
+                menu.setState(player, "hasItem", hasItem)
+
+                // Safety net: also reset if the current page now exceeds the new max.
+                // Compute directly from filteredEnchants to avoid a stale getMaxPage() value
+                // (maxPages may be evaluated before onRender fires).
+                val perPage = plugin.configYml.getInt("enchant-gui.enchant-area.width") * plugin.configYml.getInt("enchant-gui.enchant-area.height")
+                val maxPage = if (filteredEnchants.isEmpty()) {
+                    0
+                } else {
+                    ceil(filteredEnchants.size.toDouble() / perPage).toInt()
+                }
+                if (menu.getPage(player) > maxPage) {
                     menu.setState(player, Page.PAGE_KEY, 1)
                 }
             }
@@ -130,6 +167,33 @@ object EnchantGUI {
                 )
             }
 
+            // Back button to return to the group selection menu
+            if (plugin.configYml.getBool("enchant-gui.grouped")
+                && plugin.configYml.getBool("enchant-gui.back-button.enabled")) {
+                setSlot(
+                    plugin.configYml.getInt("enchant-gui.back-button.row"),
+                    plugin.configYml.getInt("enchant-gui.back-button.column"),
+                    slot(
+                        ItemStackBuilder(Items.lookup(plugin.configYml.getString("enchant-gui.back-button.item")))
+                            .addLoreLines(plugin.configYml.getStrings("enchant-gui.back-button.lore"))
+                            .build()
+                    ) {
+                        onLeftClick { event, _ ->
+                            val player = event.whoClicked as Player
+                            // Return captive items to the player before navigating back
+                            val captiveItems = menu.getCaptiveItems(player)
+                            if (captiveItems.isNotEmpty()) {
+                                DropQueue(player)
+                                    .addItems(captiveItems)
+                                    .forceTelekinesis()
+                                    .push()
+                            }
+                            groupMenu?.open(player)
+                        }
+                    }
+                )
+            }
+
             maxPages { player ->
                 val enchants = menu.getState<List<EcoEnchant>>(player, "enchants") ?: emptyList()
                 val total = enchants.size
@@ -159,10 +223,73 @@ object EnchantGUI {
                 )
             }
         }
+
+        // Build the group selection menu (only when grouped mode is enabled)
+        if (plugin.configYml.getBool("enchant-gui.grouped")) {
+            groupMenu = menu(plugin.configYml.getInt("group-gui.rows")) {
+                title = plugin.configYml.getFormattedString("group-gui.title")
+
+                setMask(
+                    FillerMask(
+                        MaskItems.fromItemNames(
+                            plugin.configYml.getStrings("group-gui.mask.items")
+                        ),
+                        *plugin.configYml.getStrings("group-gui.mask.pattern").toTypedArray()
+                    )
+                )
+
+                // Add a clickable slot for each configured group
+                for (config in plugin.configYml.getSubsections("group-gui.groups")) {
+                    val groupId = config.getString("id")
+
+                    // Validate the group ID exists in the registry matching the group-by axis
+                    val groupBy = plugin.configYml.getString("enchant-gui.group-by")
+                    val valid = when (groupBy) {
+                        "type" -> EnchantmentTypes[groupId] != null
+                        "rarity" -> EnchantmentRarities[groupId] != null
+                        "target" -> EnchantmentTargets[groupId] != null
+                        else -> false
+                    }
+
+                    if (!valid) {
+                        continue
+                    }
+
+                    setSlot(
+                        config.getInt("row"),
+                        config.getInt("column"),
+                        slot(
+                            ItemStackBuilder(Items.lookup(config.getString("item")))
+                                .addLoreLines(config.getStrings("lore"))
+                                .build()
+                        ) {
+                            onLeftClick { event, _ ->
+                                openGroupGUI(event.whoClicked as Player, groupId)
+                            }
+                        }
+                    )
+                }
+
+                // Custom decorator slots for the group menu
+                for (config in plugin.configYml.getSubsections("group-gui.custom-slots")) {
+                    setSlot(
+                        config.getInt("row"),
+                        config.getInt("column"),
+                        ConfigSlot(config)
+                    )
+                }
+            }
+        } else {
+            groupMenu = null
+        }
     }
 
     fun openGUI(player: Player) {
-        menu.open(player)
+        if (plugin.configYml.getBool("enchant-gui.grouped") && groupMenu != null) {
+            groupMenu!!.open(player)
+        } else {
+            menu.open(player)
+        }
     }
 
     fun openInfoGUI(player: Player, enchant: EcoEnchant) {
@@ -192,6 +319,12 @@ object EnchantGUI {
                 }
             }
         }.open(player)
+    }
+
+    private fun openGroupGUI(player: Player, groupId: String) {
+        menu.open(player)
+        menu.setState(player, "groupId", groupId)
+        menu.setState(player, Page.PAGE_KEY, 1)
     }
 }
 

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -174,6 +174,71 @@ enchant-gui:
   # Custom GUI slots; see here for a how-to: https://plugins.auxilor.io/all-plugins/custom-gui-slots
   custom-slots: [ ]
 
+  # If enabled, /enchant opens a group selection menu first, grouping enchantments
+  # by the group-by setting. If disabled, /enchant opens the flat enchantment list (current behavior).
+  grouped: false
+
+  # What to group enchantments by. Only used when grouped is true.
+  # Options: type (from types.yml), rarity (from rarity.yml), target (from targets.yml)
+  group-by: type
+
+  # Back button to return from a filtered sub-menu to the group selection menu.
+  # Only shown when grouped is true.
+  back-button:
+    enabled: true
+    item: arrow name:"&fBack to Groups"
+    lore: []
+    row: 6
+    column: 1
+
+# Options for the group selection GUI (only used when enchant-gui.grouped is true)
+group-gui:
+  rows: 3
+  title: "Enchantment Groups"
+
+  mask:
+    items:
+      - black_stained_glass_pane
+    pattern:
+      - "111111111"
+      - "100000001"
+      - "111111111"
+
+  # Each group must have a unique id matching an entry from the file corresponding
+  # to the group-by setting:
+  #   group-by: type   -> IDs from types.yml   (normal, spell, special, curse)
+  #   group-by: rarity -> IDs from rarity.yml  (common, uncommon, rare, epic, legendary, special, veryspecial)
+  #   group-by: target -> IDs from targets.yml (sword, pickaxe, helmet, bow, etc.)
+  # Groups with unrecognized IDs are silently ignored.
+  groups:
+    - id: normal
+      item: enchanted_book name:"&7Normal Enchantments"
+      lore:
+        - "&fClick to browse normal enchantments"
+      row: 2
+      column: 2
+    - id: spell
+      item: enchanted_book name:"<gradient:#0575E6:#1E3FBA>Spell Enchantments"
+      lore:
+        - "&fClick to browse spell enchantments"
+      row: 2
+      column: 4
+    - id: special
+      item: enchanted_book name:"<gradient:#FB57EC:#EF1DEC>Special Enchantments"
+      lore:
+        - "&fClick to browse special enchantments"
+      row: 2
+      column: 6
+    - id: curse
+      item: enchanted_book name:"&cCurse Enchantments"
+      lore:
+        - "&fClick to browse curse enchantments"
+      row: 2
+      column: 8
+
+  # Custom GUI slots; see here for a how-to: https://plugins.auxilor.io/all-plugins/custom-gui-slots
+  custom-slots: []
+
 # Options for converting lore-based enchants (from other plugins) with EcoEnchants enchantments
 # with the same names. If you're switching over from another plugin and don't want your players to
 # lose their enchantments, just switch this on.


### PR DESCRIPTION
# Feature Overview

Adds two-tier navigation to the `/ecoenchants gui` GUI. 
When the new option `enchant-gui.grouped` is:
- **enabled**, players are first shown a group selection menu, then browse a filtered sub-menu of enchantments for that group.  
- **disabled** (default), the existing behaviour is fully preserved.

# Bug Fix (additional win)

Placing or removing an item from the captive slot while on page 2+ now resets to page 1. Previously, if the filtered enchant list was shorter than the current page position, an empty page would be displayed.
