### PR TITLE
fix: improve case-insensitivity for enchant command completions

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/commands/CommandEnchantInfo.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/commands/CommandEnchantInfo.kt
@@ -56,8 +56,8 @@ object CommandEnchantInfo : PluginCommand(
         if (args.size > 1) {
             val prefix = args.dropLast(1).joinToString(" ") + " "
             val trimmed = completions.mapNotNull { completion ->
-                if (completion.startsWith(prefix)) {
-                    completion.removePrefix(prefix)
+                if (completion.startsWith(prefix, ignoreCase = true)) {
+                    completion.substring(prefix.length)
                 } else null
             }
             completions.clear()

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/EcoEnchants.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/EcoEnchants.kt
@@ -32,7 +32,7 @@ object EcoEnchants : RegistrableCategory<EcoEnchant>("enchant", "enchants") {
         for (enchant in registry.values()) {
             plugin.enchantmentRegisterer.unregister(enchant)
             EnchantRegistrations.removeEnchant(enchant)
-            BY_NAME.remove(ChatColor.stripColor(enchant.getFormattedName(0)))
+            BY_NAME.remove(ChatColor.stripColor(enchant.getFormattedName(0))?.lowercase())
         }
 
         registry.clear()
@@ -96,7 +96,7 @@ object EcoEnchants : RegistrableCategory<EcoEnchant>("enchant", "enchants") {
         // Register delegated versions
         registry.register(enchantment as EcoEnchant)
         @Suppress("DEPRECATION")
-        BY_NAME[ChatColor.stripColor(enchant.getFormattedName(0))] = enchantment as EcoEnchant
+        BY_NAME[ChatColor.stripColor(enchant.getFormattedName(0))?.lowercase()] = enchantment as EcoEnchant
         EnchantRegistrations.registerEnchantments()
     }
 
@@ -119,6 +119,6 @@ object EcoEnchants : RegistrableCategory<EcoEnchant>("enchant", "enchants") {
     fun getByName(name: String?): EcoEnchant? {
         return if (name == null) {
             null
-        } else BY_NAME[name]
+        } else BY_NAME[name.lowercase()]
     }
 }


### PR DESCRIPTION
Adds lowercase support for enchant names in /enchantinfo command.
If enchantments have spaces in their names, the tab-complete continues to suggest the name.