### PR TITLE
feat: add anvil.vanilla-costs config option

### DIFF
--- a/documentation/ecoenchants/plugin-config.md
+++ b/documentation/ecoenchants/plugin-config.md
@@ -37,6 +37,7 @@ loot:
 
 # Options for merging items in an anvil
 anvil:
+  vanilla-costs: false # If true, uses only vanilla XP costs (ignores cost-exponent).
   cost-exponent: 0.95 # The exponent for each enchant level to prevent constant "Too Expensive!" problems
   enchant-limit: -1 # The limit for the amount of enchantments on an item (-1 to disable)
   use-rework-penalty: true # If the rework penalty should be applied

--- a/eco-core/core-nms/v1_21_11/build.gradle.kts
+++ b/eco-core/core-nms/v1_21_11/build.gradle.kts
@@ -10,6 +10,12 @@ dependencies {
     paperweight.paperDevBundle("1.21.11-R0.1-SNAPSHOT")
 }
 
+// Workaround: Paper 1.21.11 dev-bundle POM declares adventure-text-serializer-ansi
+// without a version, causing Gradle resolution to fail. Force a known compatible version.
+configurations.all {
+    resolutionStrategy.force("net.kyori:adventure-text-serializer-ansi:4.23.0")
+}
+
 tasks {
     build {
         dependsOn(reobfJar)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
@@ -332,11 +332,13 @@ object AnvilSupport : Listener {
                 return@run
             }
 
-            var cost = baseRepairCost + price
-
-            // Unbelievably specific edge case
-            if (baseRepairCost == -price) {
-                cost = price
+            var cost = if (plugin.configYml.getBool("anvil.vanilla-costs")) {
+                baseRepairCost
+            } else {
+                var c = baseRepairCost + price
+                // Unbelievably specific edge case
+                if (baseRepairCost == -price) c = price
+                c
             }
 
             // Cost could be less than zero at times, so I include that here.

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -26,6 +26,7 @@ loot:
 
 # Options for merging items in an anvil
 anvil:
+  vanilla-costs: false # If true, uses only vanilla XP costs (ignores cost-exponent). Custom enchants still work.
   cost-exponent: 0.95 # The exponent for each enchant level to prevent constant "Too Expensive!" problems
   enchant-limit: -1 # The limit for the amount of enchantments on an item (-1 to disable)
   use-rework-penalty: true # If the rework penalty should be applied


### PR DESCRIPTION
I had an issue compiling with the Paper 1.21.11 dev-bundle, the POM is missing a version for adventure-text-serializer-ansi which breaks Gradle resolution. Added a forced resolution workaround which i can remove if you find it not correct.

Moving onto the real PR feature: on my SMP server I couldn't find a way to keep custom enchants without EcoEnchants also modifying vanilla anvil XP costs, so I added `anvil.vanilla-costs` (default false). When enabled, the anvil uses Minecraft's base repair cost as-is. Custom enchants still work, the plugin just won't touch the cost calculation. Handy for SMP servers that want custom enchants without messing with vanilla pricing.