### PR TITLE
Update AnvilSupport.kt

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/mechanics/AnvilSupport.kt
@@ -342,9 +342,7 @@ object AnvilSupport : Listener {
             }
 
             // Cost could be less than zero at times, so I include that here.
-            if (cost <= 0) {
-                return@run
-            }
+            if (cost <= 0) cost = 1
 
             /*
             Transplanted anti-dupe bodge from pre-recode.


### PR DESCRIPTION
Adding compatibility with my AuctionHouse plugin. The custom anvil search I use there sets the maximum repair cost to 0. Currently, no output item appears. With this simple change it works.