### PR TITLE
feat: apply custom sound framework

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/EnchantGUI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/EnchantGUI.kt
@@ -18,7 +18,7 @@ import com.willfp.eco.core.items.Items
 import com.willfp.eco.core.items.builder.EnchantedBookBuilder
 import com.willfp.eco.core.items.builder.ItemStackBuilder
 import com.willfp.eco.core.items.isEcoEmpty
-import com.willfp.eco.core.sound.PlayableSound
+import com.willfp.eco.core.sound.AbstractPlayableSound
 import com.willfp.eco.util.formatEco
 import com.willfp.eco.util.lineWrap
 import com.willfp.ecoenchants.display.EnchantSorter.sortForDisplay
@@ -143,7 +143,7 @@ object EnchantGUI {
                 pane
             )
 
-            val pageChangeSound = PlayableSound.create(
+            val pageChangeSound = AbstractPlayableSound.create(
                 plugin.configYml.getSubsection("enchant-gui.page-change.sound")
             )
 


### PR DESCRIPTION
## Summary
- eco's sound API was generalized so `PlayableSound` and `CustomPlayableSound` now both extend a new base class `AbstractPlayableSound<T>`, and `PlayableSound.create(Config)` was replaced by `AbstractPlayableSound.create(Config)`, which returns the base type.
- `EnchantGUI.kt` created its page-change sound via `PlayableSound.create(...)` and passed the result into eco's `addPageChanger` GUI helper, which now expects an `AbstractPlayableSound<*>?`. Updated the import and call site to use `AbstractPlayableSound` throughout so custom/resourcepack sounds keep working (no lossy cast to the old `PlayableSound` type).
- No dead/duplicate local sound wrapper code was found in this repo (unlike EcoCrates), so nothing else to remove.

## Test plan
- [x] `./gradlew compileJava compileKotlin` succeeds against local eco 2026.28.1 (built from the in-progress eco sound API generalization, published to the local Maven cache)