### PR TITLE
feat: add optional name translation key to enchantments

### DIFF
--- a/eco-core/core-nms/v1_21_8/src/main/kotlin/com/willfp/ecoenchants/proxy/v1_21_8/registration/EcoEnchantsCraftEnchantment.kt
+++ b/eco-core/core-nms/v1_21_8/src/main/kotlin/com/willfp/ecoenchants/proxy/v1_21_8/registration/EcoEnchantsCraftEnchantment.kt
@@ -43,7 +43,7 @@ class EcoEnchantsCraftEnchantment(
         replaceWith = ReplaceWith("this.displayName(level)")
     )
     override fun translationKey(): String {
-        return "ecoenchants:enchantment.$id"
+        return enchant.nameTranslationKey?: "ecoenchants:enchantment.$id"
     }
 
     @Deprecated(
@@ -77,7 +77,7 @@ class EcoEnchantsCraftEnchantment(
     }
 
     override fun displayName(level: Int): Component {
-        return enchant.getFormattedName(level).toComponent()
+        return enchant.nameTranslationKey?.let{Component.translatable(it, enchant.getFormattedName(level))}?: enchant.getFormattedName(level).toComponent()
     }
 
     override fun isTradeable(): Boolean {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/EcoEnchantLike.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/EcoEnchantLike.kt
@@ -44,6 +44,11 @@ interface EcoEnchantLike {
     val rawDisplayName: String
 
     /**
+     * The (optional) name translation key
+     */
+    val nameTranslationKey: String?
+
+    /**
      * The enchantment type.
      */
     val type: EnchantmentType

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/impl/EcoEnchantBase.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/impl/EcoEnchantBase.kt
@@ -45,6 +45,8 @@ abstract class EcoEnchantBase(
 
     override val rawDisplayName = config.getString("display-name")
 
+    override val nameTranslationKey = if (config.has("name-translation-key")) config.getString("name-translation-key") else null
+
     override val maximumLevel = config.getInt("max-level")
 
     override val conflictsWithEverything: Boolean

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/impl/VanillaEcoEnchantLike.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/enchant/impl/VanillaEcoEnchantLike.kt
@@ -30,6 +30,8 @@ class VanillaEcoEnchantLike(
 
     override val rawDisplayName = plugin.vanillaEnchantsYml.getString("${section}.name")
 
+    override val nameTranslationKey = if (plugin.vanillaEnchantsYml.has("${section}.name-translation-key")) plugin.vanillaEnchantsYml.getString("${section}.name-translation-key") else null
+
     override fun equals(other: Any?): Boolean {
         if (other !is VanillaEcoEnchantLike) {
             return false


### PR DESCRIPTION
Add `name-translation-key` to enchantment config sections so the name is translated in item display