### PR TITLE
feat: add toggledescriptions placeholder

### DIFF
--- a/documentation/ecoenchants/commands-and-permissions.md
+++ b/documentation/ecoenchants/commands-and-permissions.md
@@ -16,6 +16,12 @@ Every command and its permission node is listed below. Permissions follow the `e
 | `/ecoenchants export <id>`                                       | Export an enchant to [lrcdb](https://lrcdb.auxilor.io/)                 | `ecoenchants.command.export`             | 
 | `/ecoenchants toggledescriptions`                                | Let players toggle enchantment descriptions                             | `ecoenchants.command.toggledescriptions` |
 
+### PlaceholderAPI
+
+| Placeholder                          | Description                                             |
+|--------------------------------------|---------------------------------------------------------|
+| `%ecoenchants_descriptions_enabled%` | Whether the player has enchantment descriptions enabled |
+
 ### Additional permissions
 
 | Permission                   | Description                                                                                   |

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/EcoEnchantsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/EcoEnchantsPlugin.kt
@@ -14,6 +14,7 @@ import com.willfp.ecoenchants.config.RarityYml
 import com.willfp.ecoenchants.config.TargetsYml
 import com.willfp.ecoenchants.config.TypesYml
 import com.willfp.ecoenchants.config.VanillaEnchantsYml
+import com.willfp.ecoenchants.display.DescriptionEnabledPlaceholder
 import com.willfp.ecoenchants.display.DisplayCache
 import com.willfp.ecoenchants.display.EnchantDisplay
 import com.willfp.ecoenchants.display.EnchantSorter
@@ -88,6 +89,8 @@ class EcoEnchantsPlugin : LibreforgePlugin() {
                 NamedValue("level", it.level),
             )
         }
+
+        DescriptionEnabledPlaceholder.register()
 
         registerAnvilHandler()
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/display/DescriptionEnabledPlaceholder.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoenchants/display/DescriptionEnabledPlaceholder.kt
@@ -1,0 +1,13 @@
+package com.willfp.ecoenchants.display
+
+import com.willfp.eco.core.placeholder.PlayerPlaceholder
+import com.willfp.ecoenchants.commands.CommandToggleDescriptions.seesEnchantmentDescriptions
+import com.willfp.ecoenchants.plugin
+
+object DescriptionEnabledPlaceholder {
+    fun register() {
+        PlayerPlaceholder(plugin, "descriptions_enabled") { player ->
+            player.seesEnchantmentDescriptions.toString()
+        }.register()
+    }
+}


### PR DESCRIPTION
## Summary

- add `%ecoenchants_descriptions_enabled%` for PlaceholderAPI
- read from the same per-player profile value used by `/ecoenchants toggledescriptions`
- document the new placeholder alongside the command

## Motivation

Menu and UI plugins need a reliable way to show the player's actual enchantment-description preference, including changes made through the command outside those menus.

## Testing

- `./gradlew build --full-stacktrace`
- full multi-version build completed successfully (63 actionable tasks)